### PR TITLE
Add wl-clipboard to extra packages

### DIFF
--- a/community/sway/Packages-Desktop
+++ b/community/sway/Packages-Desktop
@@ -8,6 +8,7 @@ manjaro-sway/manjaro-sway-settings
 >extra kanshi # automatically load matching output profiles
 >extra autotiling # automated tiling
 >extra kitty # advanced terminal application
+>extra wl0clipboard # clipboard support for wayland
 
 # Wayland support
 xorg-xwayland # xorg-wayland bridge


### PR DESCRIPTION
Grimshot script (included in the default sway config) requires `wl-clipboard` to execute. This PR adds it to the iso profile. 